### PR TITLE
Fix page number hover color issue in archive page or other pages

### DIFF
--- a/source/css/_schemes/Mala/_posts-expand.styl
+++ b/source/css/_schemes/Mala/_posts-expand.styl
@@ -159,6 +159,7 @@ tbody tr {
     border-top-color: $search-header-background-color;
     &:hover {
       border-top-color: $orange-yellow;
+      color: $orange-yellow;
     }
   }
   .page-number.current {


### PR DESCRIPTION
The hover color of page number has a wrong setting even though the home page works perfectly.

![image](https://user-images.githubusercontent.com/12933851/118751589-2926a080-b894-11eb-8813-617444ec0e6b.png)

This PR should fix the issue for all other pages.